### PR TITLE
Querydsl을 이용한 Dao계층 리팩토링

### DIFF
--- a/services/account/account_core/account_domain/src/main/generated/org/changppo/account/service/dto/apikey/QApiKeyDto.java
+++ b/services/account/account_core/account_domain/src/main/generated/org/changppo/account/service/dto/apikey/QApiKeyDto.java
@@ -1,0 +1,21 @@
+package org.changppo.account.service.dto.apikey;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * org.changppo.account.service.dto.apikey.QApiKeyDto is a Querydsl Projection type for ApiKeyDto
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QApiKeyDto extends ConstructorExpression<ApiKeyDto> {
+
+    private static final long serialVersionUID = -1864356924L;
+
+    public QApiKeyDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> value, com.querydsl.core.types.Expression<org.changppo.account.type.GradeType> grade, com.querydsl.core.types.Expression<java.time.LocalDateTime> paymentFailureBannedAt, com.querydsl.core.types.Expression<java.time.LocalDateTime> cardDeletionBannedAt, com.querydsl.core.types.Expression<java.time.LocalDateTime> createdAt) {
+        super(ApiKeyDto.class, new Class<?>[]{long.class, String.class, org.changppo.account.type.GradeType.class, java.time.LocalDateTime.class, java.time.LocalDateTime.class, java.time.LocalDateTime.class}, id, value, grade, paymentFailureBannedAt, cardDeletionBannedAt, createdAt);
+    }
+
+}
+

--- a/services/account/account_core/account_domain/src/main/generated/org/changppo/account/service/dto/card/QCardDto.java
+++ b/services/account/account_core/account_domain/src/main/generated/org/changppo/account/service/dto/card/QCardDto.java
@@ -1,0 +1,21 @@
+package org.changppo.account.service.dto.card;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * org.changppo.account.service.dto.card.QCardDto is a Querydsl Projection type for CardDto
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QCardDto extends ConstructorExpression<CardDto> {
+
+    private static final long serialVersionUID = -595286012L;
+
+    public QCardDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> type, com.querydsl.core.types.Expression<String> issuerCorporation, com.querydsl.core.types.Expression<String> bin, com.querydsl.core.types.Expression<org.changppo.account.type.PaymentGatewayType> paymentGateway, com.querydsl.core.types.Expression<java.time.LocalDateTime> createdAt) {
+        super(CardDto.class, new Class<?>[]{long.class, String.class, String.class, String.class, org.changppo.account.type.PaymentGatewayType.class, java.time.LocalDateTime.class}, id, type, issuerCorporation, bin, paymentGateway, createdAt);
+    }
+
+}
+

--- a/services/account/account_core/account_domain/src/main/generated/org/changppo/account/service/dto/member/QMemberDto.java
+++ b/services/account/account_core/account_domain/src/main/generated/org/changppo/account/service/dto/member/QMemberDto.java
@@ -1,0 +1,21 @@
+package org.changppo.account.service.dto.member;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * org.changppo.account.service.dto.member.QMemberDto is a Querydsl Projection type for MemberDto
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QMemberDto extends ConstructorExpression<MemberDto> {
+
+    private static final long serialVersionUID = -784235196L;
+
+    public QMemberDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<String> name, com.querydsl.core.types.Expression<String> username, com.querydsl.core.types.Expression<String> profileImage, com.querydsl.core.types.Expression<? extends java.util.Set<org.changppo.account.type.RoleType>> roles, com.querydsl.core.types.Expression<java.time.LocalDateTime> paymentFailureBannedAt, com.querydsl.core.types.Expression<java.time.LocalDateTime> createdAt) {
+        super(MemberDto.class, new Class<?>[]{long.class, String.class, String.class, String.class, java.util.Set.class, java.time.LocalDateTime.class, java.time.LocalDateTime.class}, id, name, username, profileImage, roles, paymentFailureBannedAt, createdAt);
+    }
+
+}
+

--- a/services/account/account_core/account_domain/src/main/generated/org/changppo/account/service/dto/payment/QPaymentDto.java
+++ b/services/account/account_core/account_domain/src/main/generated/org/changppo/account/service/dto/payment/QPaymentDto.java
@@ -1,0 +1,21 @@
+package org.changppo.account.service.dto.payment;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.ConstructorExpression;
+import javax.annotation.processing.Generated;
+
+/**
+ * org.changppo.account.service.dto.payment.QPaymentDto is a Querydsl Projection type for PaymentDto
+ */
+@Generated("com.querydsl.codegen.DefaultProjectionSerializer")
+public class QPaymentDto extends ConstructorExpression<PaymentDto> {
+
+    private static final long serialVersionUID = 1164874004L;
+
+    public QPaymentDto(com.querydsl.core.types.Expression<Long> id, com.querydsl.core.types.Expression<? extends java.math.BigDecimal> amount, com.querydsl.core.types.Expression<org.changppo.account.type.PaymentStatus> status, com.querydsl.core.types.Expression<java.time.LocalDateTime> startedAt, com.querydsl.core.types.Expression<java.time.LocalDateTime> endedAt, com.querydsl.core.types.Expression<? extends org.changppo.account.entity.payment.PaymentCardInfo> cardInfo, com.querydsl.core.types.Expression<java.time.LocalDateTime> createdAt) {
+        super(PaymentDto.class, new Class<?>[]{long.class, java.math.BigDecimal.class, org.changppo.account.type.PaymentStatus.class, java.time.LocalDateTime.class, java.time.LocalDateTime.class, org.changppo.account.entity.payment.PaymentCardInfo.class, java.time.LocalDateTime.class}, id, amount, status, startedAt, endedAt, cardInfo, createdAt);
+    }
+
+}
+

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/config/QuerydslConfig.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/config/QuerydslConfig.java
@@ -2,18 +2,18 @@ package org.changppo.account.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@RequiredArgsConstructor
 public class QuerydslConfig {
 
-    private final EntityManager em;
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Bean
-    public JPAQueryFactory jpaQueryFactory(EntityManager em){
-        return new JPAQueryFactory(em);
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
     }
 }

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/apikey/ApiKeyRepository.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/apikey/ApiKeyRepository.java
@@ -1,52 +1,13 @@
 package org.changppo.account.repository.apikey;
 
 import org.changppo.account.entity.apikey.ApiKey;
-import org.changppo.account.service.dto.apikey.ApiKeyDto;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
-public interface ApiKeyRepository extends JpaRepository<ApiKey, Long> {  //TODO. 복잡한 쿼리는 Querydsl로 변경
-    @Query("select new org.changppo.account.service.dto.apikey.ApiKeyDto(a.id, a.value, a.grade.gradeType, a.paymentFailureBannedAt, a.cardDeletionBannedAt, a.createdAt) " +
-            "from ApiKey a where a.member.id = :memberId and a.id >= :firstApiKeyId " +
-            "order by a.id asc")
-    Slice<ApiKeyDto> findAllByMemberIdOrderByAsc(@Param("memberId") Long memberId, @Param("firstApiKeyId") Long firstApiKeyId, Pageable pageable);
-
-    void deleteAllByMemberId(Long memberId);
-
+public interface ApiKeyRepository extends JpaRepository<ApiKey, Long> , QuerydslApiKeyRepository {
     Optional<ApiKey> findByValue(String value);
-
     long countByMemberId(Long memberId);
-
-    @Modifying
-    @Query("UPDATE ApiKey a SET a.cardDeletionBannedAt = :time WHERE a.member.id = :memberId AND a.grade.gradeType != 'GRADE_FREE'")
-    void banForCardDeletionByMemberId(@Param("memberId")Long memberId, @Param("time") LocalDateTime time);
-
-    @Modifying
-    @Query("UPDATE ApiKey a SET a.cardDeletionBannedAt = NULL WHERE a.member.id = :memberId AND a.grade.gradeType != 'GRADE_FREE'")
-    void unbanForCardDeletionByMemberId(@Param("memberId")Long memberId);
-
-    @Modifying
-    @Query("UPDATE ApiKey a SET a.paymentFailureBannedAt = :time WHERE a.member.id = :memberId")
-    void banApiKeysForPaymentFailure(@Param("memberId") Long memberId, @Param("time") LocalDateTime time);
-
-    @Modifying
-    @Query("UPDATE ApiKey a SET a.paymentFailureBannedAt = NULL WHERE a.member.id = :memberId")
-    void unbanApiKeysForPaymentFailure(@Param("memberId") Long memberId);
-
-    @Modifying
-    @Query("UPDATE ApiKey a SET a.deletionRequestedAt = :time WHERE a.member.id = :memberId")
-    void requestApiKeyDeletion(@Param("memberId") Long memberId, @Param("time") LocalDateTime time);
-
-    @Modifying
-    @Query("UPDATE ApiKey a SET a.deletionRequestedAt = NULL WHERE a.member.id = :memberId")
-    void cancelApiKeyDeletionRequest(@Param("memberId") Long memberId);
 }

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/apikey/ApiKeyRepositoryImpl.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/apikey/ApiKeyRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.changppo.account.service.dto.apikey.QApiKeyDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -55,7 +56,7 @@ public class ApiKeyRepositoryImpl implements QuerydslApiKeyRepository {
     public void banForCardDeletionByMemberId(Long memberId, LocalDateTime time) {
         queryFactory.update(apiKey)
                 .set(apiKey.cardDeletionBannedAt, time)
-                .where(memberIdEquals(memberId).and(apiKey.grade.gradeType.ne(GRADE_FREE)))
+                .where(memberIdEquals(memberId).and(statusNotGradeFree()))
                 .execute();
     }
 
@@ -63,7 +64,7 @@ public class ApiKeyRepositoryImpl implements QuerydslApiKeyRepository {
     public void unbanForCardDeletionByMemberId(Long memberId) {
         queryFactory.update(apiKey)
                 .set(apiKey.cardDeletionBannedAt, (LocalDateTime) null)
-                .where(memberIdEquals(memberId).and(apiKey.grade.gradeType.ne(GRADE_FREE)))
+                .where(memberIdEquals(memberId).and(statusNotGradeFree()))
                 .execute();
     }
 
@@ -104,5 +105,9 @@ public class ApiKeyRepositoryImpl implements QuerydslApiKeyRepository {
 
     private BooleanExpression apiKeyIdGreaterThanOrEqual(Long apiKeyId) {
         return apiKeyId != null ? apiKey.id.goe(apiKeyId) : null;
+    }
+
+    private BooleanExpression statusNotGradeFree() {
+        return apiKey.grade.gradeType.ne(GRADE_FREE);
     }
 }

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/apikey/ApiKeyRepositoryImpl.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/apikey/ApiKeyRepositoryImpl.java
@@ -1,0 +1,108 @@
+package org.changppo.account.repository.apikey;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.changppo.account.service.dto.apikey.ApiKeyDto;
+import org.changppo.account.service.dto.apikey.QApiKeyDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.changppo.account.entity.apikey.QApiKey.apiKey;
+import static org.changppo.account.type.GradeType.GRADE_FREE;
+
+@RequiredArgsConstructor
+public class ApiKeyRepositoryImpl implements QuerydslApiKeyRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<ApiKeyDto> findAllByMemberIdOrderByAsc(Long memberId, Long firstApiKeyId, Pageable pageable) {
+        List<ApiKeyDto> apiKeyDtos = queryFactory.select(
+                new QApiKeyDto(
+                        apiKey.id,
+                        apiKey.value,
+                        apiKey.grade.gradeType,
+                        apiKey.paymentFailureBannedAt,
+                        apiKey.cardDeletionBannedAt,
+                        apiKey.createdAt))
+                .from(apiKey)
+                .where(memberIdEquals(memberId).and(apiKeyIdGreaterThanOrEqual(firstApiKeyId)))
+                .orderBy(apiKey.id.asc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = apiKeyDtos.size() > pageable.getPageSize();
+        if (hasNext) {
+            apiKeyDtos.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(apiKeyDtos, pageable, hasNext);
+    }
+
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        queryFactory.delete(apiKey)
+                .where(memberIdEquals(memberId))
+                .execute();
+    }
+
+    @Override
+    public void banForCardDeletionByMemberId(Long memberId, LocalDateTime time) {
+        queryFactory.update(apiKey)
+                .set(apiKey.cardDeletionBannedAt, time)
+                .where(memberIdEquals(memberId).and(apiKey.grade.gradeType.ne(GRADE_FREE)))
+                .execute();
+    }
+
+    @Override
+    public void unbanForCardDeletionByMemberId(Long memberId) {
+        queryFactory.update(apiKey)
+                .set(apiKey.cardDeletionBannedAt, (LocalDateTime) null)
+                .where(memberIdEquals(memberId).and(apiKey.grade.gradeType.ne(GRADE_FREE)))
+                .execute();
+    }
+
+    @Override
+    public void banApiKeysForPaymentFailure(Long memberId, LocalDateTime time) {
+        queryFactory.update(apiKey)
+                .set(apiKey.paymentFailureBannedAt, time)
+                .where(memberIdEquals(memberId))
+                .execute();
+    }
+
+    @Override
+    public void unbanApiKeysForPaymentFailure(Long memberId) {
+        queryFactory.update(apiKey)
+                .set(apiKey.paymentFailureBannedAt, (LocalDateTime) null)
+                .where(memberIdEquals(memberId))
+                .execute();
+    }
+
+    @Override
+    public void requestApiKeyDeletion(Long memberId, LocalDateTime time) {
+        queryFactory.update(apiKey)
+                .set(apiKey.deletionRequestedAt, time)
+                .where(memberIdEquals(memberId))
+                .execute();
+    }
+
+    @Override
+    public void cancelApiKeyDeletionRequest(Long memberId) {
+        queryFactory.update(apiKey)
+                .set(apiKey.deletionRequestedAt, (LocalDateTime) null)
+                .where(memberIdEquals(memberId))
+                .execute();
+    }
+    private BooleanExpression memberIdEquals(Long memberId) {
+        return apiKey.member.id.eq(memberId);
+    }
+
+    private BooleanExpression apiKeyIdGreaterThanOrEqual(Long apiKeyId) {
+        return apiKeyId != null ? apiKey.id.goe(apiKeyId) : null;
+    }
+}

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/apikey/QuerydslApiKeyRepository.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/apikey/QuerydslApiKeyRepository.java
@@ -1,0 +1,18 @@
+package org.changppo.account.repository.apikey;
+
+import org.changppo.account.service.dto.apikey.ApiKeyDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
+
+public interface QuerydslApiKeyRepository {
+    Slice<ApiKeyDto> findAllByMemberIdOrderByAsc(Long memberId, Long firstApiKeyId, Pageable pageable);
+    void deleteAllByMemberId(Long memberId);
+    void banForCardDeletionByMemberId(Long memberId, LocalDateTime time);
+    void unbanForCardDeletionByMemberId(Long memberId);
+    void banApiKeysForPaymentFailure(Long memberId, LocalDateTime time);
+    void unbanApiKeysForPaymentFailure(Long memberId);
+    void requestApiKeyDeletion(Long memberId, LocalDateTime time);
+    void cancelApiKeyDeletionRequest(Long memberId);
+}

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/card/CardRepository.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/card/CardRepository.java
@@ -1,28 +1,12 @@
 package org.changppo.account.repository.card;
 
 import org.changppo.account.entity.card.Card;
-import org.changppo.account.service.dto.card.CardDto;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface CardRepository extends JpaRepository<Card, Long> {  //TODO. 복잡한 쿼리는 Querydsl로 변경
-    @Query("select new org.changppo.account.service.dto.card.CardDto(c.id, c.type, c.issuerCorporation, c.bin, c.paymentGateway.paymentGatewayType, c.createdAt) " +
-            "from Card c where c.member.id = :memberId " +
-            "order by c.id asc")
-    List<CardDto> findAllByMemberId(@Param("memberId") Long memberId);
-
-    long countByMemberId(Long memberId);
-
-    void deleteAllByMemberId(Long memberId);
-
+public interface CardRepository extends JpaRepository<Card, Long> , QuerydslCardRepository{
     Optional<Card> findByKey(String key);
-
-    @Query("select c from Card c where c.member.id = :memberId order by c.id asc")
-    List<Card> findAllCardByMemberId(@Param("memberId") Long memberId);
 }

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/card/CardRepositoryImpl.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/card/CardRepositoryImpl.java
@@ -1,0 +1,62 @@
+package org.changppo.account.repository.card;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.changppo.account.entity.card.Card;
+import org.changppo.account.service.dto.card.CardDto;
+import org.changppo.account.service.dto.card.QCardDto;
+import java.util.List;
+
+import static org.changppo.account.entity.card.QCard.card;
+
+@RequiredArgsConstructor
+public class CardRepositoryImpl implements QuerydslCardRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Card> findAllCardByMemberIdOrderByAsc(Long memberId) {
+        return queryFactory.selectFrom(card)
+                .where(memberIdEquals(memberId))
+                .orderBy(card.id.asc())
+                .fetch();
+    }
+
+    @Override
+    public long countByMemberId(Long memberId) {
+        Long count = queryFactory.select(card.count())
+                .from(card)
+                .where(memberIdEquals(memberId))
+                .fetchOne();
+
+        return count != null ? count : 0;
+    }
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        queryFactory.delete(card)
+                .where(memberIdEquals(memberId))
+                .execute();
+    }
+
+    @Override
+    public List<CardDto> findAllByMemberIdOrderByAsc(Long memberId) {
+        return queryFactory.select(
+                new QCardDto(
+                        card.id,
+                        card.type,
+                        card.issuerCorporation,
+                        card.bin,
+                        card.paymentGateway.paymentGatewayType,
+                        card.createdAt))
+                .from(card)
+                .where(memberIdEquals(memberId))
+                .orderBy(card.id.asc())
+                .fetch();
+    }
+
+    private BooleanExpression memberIdEquals(Long memberId) {
+        return card.member.id.eq(memberId);
+    }
+}

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/card/QuerydslCardRepository.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/card/QuerydslCardRepository.java
@@ -1,0 +1,13 @@
+package org.changppo.account.repository.card;
+
+import org.changppo.account.entity.card.Card;
+import org.changppo.account.service.dto.card.CardDto;
+
+import java.util.List;
+
+public interface QuerydslCardRepository {
+    List<Card> findAllCardByMemberIdOrderByAsc(Long memberId);
+    long countByMemberId(Long memberId);
+    void deleteAllByMemberId(Long memberId);
+    List<CardDto> findAllByMemberIdOrderByAsc(Long memberId);
+}

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/payment/PaymentRepository.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/payment/PaymentRepository.java
@@ -1,24 +1,13 @@
 package org.changppo.account.repository.payment;
 
 import org.changppo.account.entity.payment.Payment;
-import org.changppo.account.service.dto.payment.PaymentDto;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface PaymentRepository extends JpaRepository<Payment, Long> {  //TODO. 복잡한 쿼리는 Querydsl로 변경
-    void deleteAllByMemberId(Long memberId);
-    Optional<Payment> findFirstByMemberIdOrderByEndedAtDesc(Long memberId);
-    @Query("select new org.changppo.account.service.dto.payment.PaymentDto(p.id, p.amount, p.status, p.startedAt, p.endedAt, p.cardInfo, p.createdAt)" +
-            "from Payment p where p.member.id = :memberId and p.id <= :lastPaymentId and p.status != 'COMPLETED_FREE' " +
-            "order by p.id desc")
-    Slice<PaymentDto> findAllByMemberIdAndStatusNotCompletedFree(@Param("memberId") Long memberId, @Param("lastPaymentId") Long lastPaymentId, Pageable pageable);
+public interface PaymentRepository extends JpaRepository<Payment, Long> , QuerydslPaymentRepository{
     Optional<Payment> findByKey(String key);
     long countByMemberId(Long memberId);
     Optional<Payment> findTopByMemberIdOrderByEndedAtDesc(Long memberId);

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/payment/PaymentRepositoryImpl.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/payment/PaymentRepositoryImpl.java
@@ -1,0 +1,76 @@
+package org.changppo.account.repository.payment;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.changppo.account.entity.payment.Payment;
+import org.changppo.account.service.dto.payment.PaymentDto;
+import org.changppo.account.service.dto.payment.QPaymentDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import java.util.List;
+import java.util.Optional;
+
+import static org.changppo.account.entity.payment.QPayment.payment;
+import static org.changppo.account.type.PaymentStatus.COMPLETED_FREE;
+
+@RequiredArgsConstructor
+public class PaymentRepositoryImpl implements QuerydslPaymentRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        queryFactory.delete(payment)
+                .where(memberIdEquals(memberId))
+                .execute();
+    }
+
+    @Override
+    public Optional<Payment> findFirstByMemberIdOrderByEndedAtDesc(Long memberId) {
+        return Optional.ofNullable(queryFactory.selectFrom(payment)
+                .where(memberIdEquals(memberId))
+                .orderBy(payment.endedAt.desc())
+                .fetchFirst());
+    }
+
+    @Override
+    public Slice<PaymentDto> findAllByMemberIdAndStatusNotCompletedFree(Long memberId, Long lastPaymentId, Pageable pageable) {
+        List<PaymentDto> results = queryFactory.select(
+                new QPaymentDto(
+                        payment.id,
+                        payment.amount,
+                        payment.status,
+                        payment.startedAt,
+                        payment.endedAt,
+                        payment.cardInfo,
+                        payment.createdAt))
+                .from(payment)
+                .where(memberIdEquals(memberId)
+                        .and(paymentIdLessThanOrEqual(lastPaymentId))
+                        .and(statusNotCompletedFree()))
+                .orderBy(payment.id.desc())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = results.size() > pageable.getPageSize();
+        if (hasNext) {
+            results.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    private BooleanExpression memberIdEquals(Long memberId) {
+        return payment.member.id.eq(memberId);
+    }
+
+    private BooleanExpression paymentIdLessThanOrEqual(Long lastPaymentId) {
+        return lastPaymentId != null ? payment.id.loe(lastPaymentId) : null;
+    }
+
+    private BooleanExpression statusNotCompletedFree() {
+        return payment.status.ne(COMPLETED_FREE);
+    }
+}

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/payment/QuerydslPaymentRepository.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/repository/payment/QuerydslPaymentRepository.java
@@ -1,0 +1,14 @@
+package org.changppo.account.repository.payment;
+
+import org.changppo.account.entity.payment.Payment;
+import org.changppo.account.service.dto.payment.PaymentDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.Optional;
+
+public interface QuerydslPaymentRepository {
+    void deleteAllByMemberId(Long memberId);
+    Optional<Payment> findFirstByMemberIdOrderByEndedAtDesc(Long memberId);
+    Slice<PaymentDto> findAllByMemberIdAndStatusNotCompletedFree(Long memberId, Long lastPaymentId, Pageable pageable);
+}

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/service/dto/apikey/ApiKeyDto.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/service/dto/apikey/ApiKeyDto.java
@@ -1,13 +1,13 @@
 package org.changppo.account.service.dto.apikey;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 import org.changppo.account.type.GradeType;
+
 import java.time.LocalDateTime;
 
 @Data
-@AllArgsConstructor
 public class ApiKeyDto {
     private Long id;
     private String value;
@@ -18,4 +18,14 @@ public class ApiKeyDto {
     private LocalDateTime cardDeletionBannedAt;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
+
+    @QueryProjection
+    public ApiKeyDto(Long id, String value, GradeType grade, LocalDateTime paymentFailureBannedAt, LocalDateTime cardDeletionBannedAt, LocalDateTime createdAt) {
+        this.id = id;
+        this.value = value;
+        this.grade = grade;
+        this.paymentFailureBannedAt = paymentFailureBannedAt;
+        this.cardDeletionBannedAt = cardDeletionBannedAt;
+        this.createdAt = createdAt;
+    }
 }

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/service/dto/card/CardDto.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/service/dto/card/CardDto.java
@@ -1,14 +1,13 @@
 package org.changppo.account.service.dto.card;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 import org.changppo.account.type.PaymentGatewayType;
 
 import java.time.LocalDateTime;
 
 @Data
-@AllArgsConstructor
 public class CardDto {
     private Long id;
     private String type;
@@ -17,4 +16,14 @@ public class CardDto {
     private PaymentGatewayType paymentGateway;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
+
+    @QueryProjection
+    public CardDto(Long id, String type, String issuerCorporation, String bin, PaymentGatewayType paymentGateway, LocalDateTime createdAt) {
+        this.id = id;
+        this.type = type;
+        this.issuerCorporation = issuerCorporation;
+        this.bin = bin;
+        this.paymentGateway = paymentGateway;
+        this.createdAt = createdAt;
+    }
 }

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/service/dto/member/MemberDto.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/service/dto/member/MemberDto.java
@@ -1,15 +1,14 @@
 package org.changppo.account.service.dto.member;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
 import org.changppo.account.type.RoleType;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 
-@Getter
-@AllArgsConstructor
+@Data
 public class MemberDto {
     private Long id;
     private String name;
@@ -20,4 +19,15 @@ public class MemberDto {
     private LocalDateTime paymentFailureBannedAt;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
+
+    @QueryProjection
+    public MemberDto(Long id, String name, String username, String profileImage, Set<RoleType> roles, LocalDateTime paymentFailureBannedAt, LocalDateTime createdAt) {
+        this.id = id;
+        this.name = name;
+        this.username = username;
+        this.profileImage = profileImage;
+        this.roles = roles;
+        this.paymentFailureBannedAt = paymentFailureBannedAt;
+        this.createdAt = createdAt;
+    }
 }

--- a/services/account/account_core/account_domain/src/main/java/org/changppo/account/service/dto/payment/PaymentDto.java
+++ b/services/account/account_core/account_domain/src/main/java/org/changppo/account/service/dto/payment/PaymentDto.java
@@ -1,15 +1,15 @@
 package org.changppo.account.service.dto.payment;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
 import org.changppo.account.entity.payment.PaymentCardInfo;
 import org.changppo.account.type.PaymentStatus;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-@Getter
-@AllArgsConstructor
+
+@Data
 public class PaymentDto {
     private Long id;
     private BigDecimal amount;
@@ -21,4 +21,15 @@ public class PaymentDto {
     private PaymentCardInfo cardInfo;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
+
+    @QueryProjection
+    public PaymentDto(Long id, BigDecimal amount, PaymentStatus status, LocalDateTime startedAt, LocalDateTime endedAt, PaymentCardInfo cardInfo, LocalDateTime createdAt) {
+        this.id = id;
+        this.amount = amount;
+        this.status = status;
+        this.startedAt = startedAt;
+        this.endedAt = endedAt;
+        this.cardInfo = cardInfo;
+        this.createdAt = createdAt;
+    }
 }

--- a/services/account/account_core/account_infra/src/main/java/org/changppo/account/oauth2/github/GitHubConstants.java
+++ b/services/account/account_core/account_infra/src/main/java/org/changppo/account/oauth2/github/GitHubConstants.java
@@ -2,6 +2,10 @@ package org.changppo.account.oauth2.github;
 
 public class GitHubConstants {
     public static final String GITHUB_REGISTRATION_ID = "github";
+    public static final String GITHUB_ID = "id";
+    public static final String GITHUB_NICKNAME = "name";
+    public static final String GITHUB_PROFILE_IMAGE_URL = "avatar_url";
+
     public static final String GITHUB_URL = "https://api.github.com/applications/";
     public static final String GITHUB_UNLINK_URL = "/grant";
 }

--- a/services/account/account_server-api/src/main/java/org/changppo/account/security/oauth2/response/GitHubResponse.java
+++ b/services/account/account_server-api/src/main/java/org/changppo/account/security/oauth2/response/GitHubResponse.java
@@ -2,6 +2,7 @@ package org.changppo.account.security.oauth2.response;
 
 import java.util.Map;
 
+import static org.changppo.account.oauth2.github.GitHubConstants.*;
 import static org.changppo.account.type.OAuth2Type.OAUTH2_GITHUB;
 
 public class GitHubResponse implements OAuth2Response {
@@ -19,16 +20,16 @@ public class GitHubResponse implements OAuth2Response {
 
     @Override
     public String getProviderId() {
-        return attribute.get("id").toString();
+        return attribute.get(GITHUB_ID).toString();
     }
 
     @Override
     public String getName() {
-        return attribute.get("name").toString();
+        return attribute.get(GITHUB_NICKNAME).toString();
     }
 
     @Override
     public String getProfileImage() {
-        return attribute.get("avatar_url").toString();
+        return attribute.get(GITHUB_PROFILE_IMAGE_URL).toString();
     }
 }

--- a/services/account/account_server-api/src/main/java/org/changppo/account/service/card/CardService.java
+++ b/services/account/account_server-api/src/main/java/org/changppo/account/service/card/CardService.java
@@ -101,7 +101,7 @@ public class CardService {
 
     @PreAuthorize("@memberAccessEvaluator.check(#memberId)")
     public CardListDto readAll(@Param("memberId")Long memberId){
-        List<CardDto> cards = cardRepository.findAllByMemberId(memberId);
+        List<CardDto> cards = cardRepository.findAllByMemberIdOrderByAsc(memberId);
         return new CardListDto(cards);
     }
 
@@ -127,7 +127,7 @@ public class CardService {
                 .inactive(card.getKey());
     }
 
-    private boolean isLastCard(Card card) {
+    private boolean isLastCard(Card card) {  // TODO. 동시성 문제 확인
         return cardRepository.countByMemberId(card.getMember().getId()) == 0;
     }
 

--- a/services/account/account_server-batch/src/main/java/org/changppo/account/batch/job/JobConfig.java
+++ b/services/account/account_server-batch/src/main/java/org/changppo/account/batch/job/JobConfig.java
@@ -117,7 +117,7 @@ public class JobConfig {
         return new StepBuilder("executePaymentStep", jobRepository)
                 .tasklet((contribution, chunkContext) -> {
                     try {
-                        List<Card> cards = cardRepository.findAllCardByMemberId(memberId);
+                        List<Card> cards = cardRepository.findAllCardByMemberIdOrderByAsc(memberId);
                         PaymentExecutionJobResponse paymentExecutionJobResponse = cards.stream()
                                 .map(card -> processPayment(card, memberId, new BigDecimal(amount)))
                                 .filter(Objects::nonNull)

--- a/services/account/account_server-batch/src/main/java/org/changppo/account/batch/job/WriterConfig.java
+++ b/services/account/account_server-batch/src/main/java/org/changppo/account/batch/job/WriterConfig.java
@@ -99,7 +99,7 @@ public class WriterConfig {
     }
 
     private void inactivePaymentGatewayCards(Long memberId) {
-        List<Card> cards = cardRepository.findAllCardByMemberId(memberId);
+        List<Card> cards = cardRepository.findAllCardByMemberIdOrderByAsc(memberId);
         cards.forEach(card -> {
             PaymentGatewayType paymentGatewayType = card.getPaymentGateway().getPaymentGatewayType();
             paymentGatewayClients.stream()

--- a/services/account/account_server-batch/src/test/java/org/changppo/account/job/AutomaticPaymentExecutionJobTest.java
+++ b/services/account/account_server-batch/src/test/java/org/changppo/account/job/AutomaticPaymentExecutionJobTest.java
@@ -29,7 +29,10 @@ import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
 
 import static org.changppo.account.batch.job.JobConfig.AUTOMATIC_PAYMENT_JOB;
 import static org.changppo.account.builder.card.paymentgateway.kakaopay.KakaopayResponseBuilder.buildKakaopayApproveResponse;
@@ -134,9 +137,17 @@ public class AutomaticPaymentExecutionJobTest { //TODO. 비용집계 서버와 �
     }
 
     private JobParameters buildJobParameters() {
+        LocalDateTime lastSunday = calculateLastSunday(LocalDateTime.now());
+        LocalDateTime jobStartTime = lastSunday.plusDays(2);
+
         return new JobParametersBuilder()
-                .addLocalDateTime("JobStartTime", LocalDateTime.now().plusDays(3))
+                .addLocalDateTime("JobStartTime", jobStartTime)
                 .toJobParameters();
+    }
+
+    private LocalDateTime calculateLastSunday(LocalDateTime dateTime) {
+        return dateTime.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY))
+                .with(LocalTime.of(23, 59, 59));
     }
 
     private String convertToJson(Object object) throws IOException {


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #38 

## ✨ PR 세부 내용
- Querydsl을 이용한 Dao 계층을 구성하였습니다. 기존에는 Spring Data JPA의 @Query를 이용하여 JPQL을 사용했지만, 이를 Querydsl로 전환하였습니다.
- 본래는 이번 PR에서 Dao에 대한 단위 테스트를 작성하려고 했으나, 협업을 위한 공용 설정 프로젝트를 구성한 뒤, 단위 테스트 코드를 작성하여 PR 올리겠습니다.